### PR TITLE
Clear old messages on update. Remove caching.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-phpstan",
-    "version": "0.1.3",
+    "version": "0.1.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-phpstan",
     "displayName": "vscode-phpstan",
     "description": "PHPStan support in VSCode",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "publisher": "Calsmurf2904",
     "engines": {
         "vscode": "^1.19.0"

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -14,7 +14,6 @@ export class PHPStanController
         let subscriptions: Disposable[] = [];
         workspace.onDidSaveTextDocument(this._onDocumentEvent, this, subscriptions);
         workspace.onDidOpenTextDocument(this._onDocumentEvent, this, subscriptions);
-        workspace.onDidChangeTextDocument(this._onDocumentChangeEvent, this, subscriptions);
         window.onDidChangeActiveTextEditor(this._onEditorEvent, this, subscriptions);
 
         // Get the current text editor
@@ -31,14 +30,11 @@ export class PHPStanController
         this._phpstan.updateDocument(e);
     }
 
-    private _onDocumentChangeEvent(e: TextDocumentChangeEvent)
+    private _onEditorEvent(e: TextEditor|undefined)
     {
+      if (e !== undefined) {
         this._phpstan.updateDocument(e.document);
-    }
-    
-    private _onEditorEvent(e: TextEditor)
-    {
-        this._phpstan.updateDocument(e.document);
+      }
     }
 
     dispose()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,19 +11,17 @@ export function handleDiagnosticErrors(document: TextDocument[], errors: ICheckR
 
     let diagnosticMap: Map<string, Diagnostic[]> = new Map();
     errors.forEach(error => {
-        let canonicalFile = Uri.file(error.file).toString();
+        const canonicalFile = Uri.file(error.file).toString();
+        const doc = document.find((item) => item.uri.toString() === canonicalFile);
         let startColumn = 0;
         let endColumn = 1;
 
-        for (const doc of document) {
-            if (doc.uri.toString() === canonicalFile) {
-                let range = new Range(error.line - 1, 0, error.line - 1, doc.lineAt(error.line - 1).range.end.character + 1);
-                let text = doc.getText(range);
-                let [_, leading, trailing] = /^(\s*).*(\s*)$/.exec(text);
-                startColumn = leading.length;
-                endColumn = text.length - trailing.length;
-                break;
-            }
+        if (doc !== undefined) {
+            let range = new Range(error.line - 1, 0, error.line - 1, doc.lineAt(error.line - 1).range.end.character + 1);
+            let text = doc.getText(range);
+            let [_, leading, trailing] = /^(\s*).*(\s*)$/.exec(text);
+            startColumn = leading.length;
+            endColumn = text.length - trailing.length;
         }
 
         let range = new Range(error.line - 1, startColumn, error.line - 1, endColumn);


### PR DESCRIPTION
The old messages need to always be cleared on an update. This prevents fixed problems from being seen until a reload. Fixes #3

The caching of old errors is unnecessary and also lead to #3. Users always want the latest errors to be shown only. Removing the cache reduces the complexity of the code to maintain.

With this, I also updated a parameter name from `doc` to `updatedDocument` which makes the method far easier to read.