### PR TITLE
Fix the active text editor URI

### DIFF
--- a/src/phpstan.ts
+++ b/src/phpstan.ts
@@ -56,8 +56,8 @@ export class PHPStan {
         this._numActive = 0;
         this._numQueued = 0;
 
-        this._command = commands.registerCommand("extension.scanForErrors", (file) => {
-            const path = file["fsPath"];
+        this._command = commands.registerCommand("extension.scanForErrors", () => {
+            const path = window.activeTextEditor.document.uri.fsPath;
 
             if (fs.lstatSync(path).isDirectory()) {
                 this.scanDirectory(path);


### PR DESCRIPTION
This fix issue breaks the extension. on vs-code v1.68.1 not sure about older versions.